### PR TITLE
Fix depth regular expression to math also very small numbers.

### DIFF
--- a/latex2svg.py
+++ b/latex2svg.py
@@ -131,7 +131,7 @@ def latex2svg(code, params=default_params, working_directory=None):
             return None, None
 
     def get_measure(output, name):
-        regex = r'\b%s=([0-9.]+)pt' % name
+        regex = r'\b%s=([0-9.e-]+)pt' % name
         match = re.search(regex, output)
         if match:
             return float(match.group(1)) / fontsize


### PR DESCRIPTION
Sometimes depth value of e.g. `1.234e-5pt` is returned by dvisvgm, in which case latex2svg returned `None`, causing problems for code that always assumed a number. This is fixed now.

Thanks for this great little tool, btw! Very useful.