### PR TITLE
Fix finding of libgs on Linux

### DIFF
--- a/latex2svg.py
+++ b/latex2svg.py
@@ -49,7 +49,7 @@ default_params = {
 }
 
 
-if not hasattr(os.environ, 'LIBGS') and not find_library('libgs'):
+if not hasattr(os.environ, 'LIBGS') and not find_library('gs'):
     if sys.platform == 'darwin':
         # Fallback to homebrew Ghostscript on macOS
         homebrew_libgs = '/usr/local/opt/ghostscript/lib/libgs.dylib'


### PR DESCRIPTION
On Linux it should look for 'gs' instead of 'libgs'. Fixes the "Warning: libgs not found" message.

(Got this patch from @gotchafr so I'm sharing it upstream. Thank you!)