### PR TITLE
Properly print also dvisvgm output on error

### DIFF
--- a/latex2svg.py
+++ b/latex2svg.py
@@ -174,7 +174,10 @@ def main():
         meta = {key: out[key] for key in out if key != 'svg'}
         sys.stderr.write(json.dumps(meta))
     except subprocess.CalledProcessError as exc:
+        # LaTeX prints errors on stdout instead of stderr (stderr is empty),
+        # dvisvgm to stderr, so print both
         print(exc.output.decode('utf-8'))
+        print(exc.stderr.decode('utf-8'))
         sys.exit(exc.returncode)
 
 


### PR DESCRIPTION
Hi @tuxu, another small patch from me -- I'm using this to render formulas for [Doxygen documentation](http://mcss.mosra.cz/doxygen/) and it was quite annoying that if I got an error in my formula, the script was not printing out any info from LaTeX or dvisvgm, making it hard to debug. This fixes that.

Thanks in advance for merging! :)